### PR TITLE
fix: ci tests failing on linux

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,6 +20,7 @@ jobs:
 
   cpython:
     runs-on: ubuntu-latest
+    container: ubuntu
     strategy:
       matrix:
         python: ["3.10", "3.11", "3.12"]

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -70,7 +70,7 @@ class TestDefaultWebServer(unittest.TestCase):
         async def error_route(req, resp):
             raise Exception("Test Exception")
 
-        self.app = uwebserver.WebServer(host=HOST, port=PORT, request_timeout=1)
+        self.app = uwebserver.WebServer(port=PORT, request_timeout=1)
         self.app.add_route("/error", error_route)
 
         self.loop = asyncio.new_event_loop()
@@ -163,7 +163,7 @@ class TestWebServer(unittest.TestCase):
             resp.set_status(b"500 Internal Server Error")
             return "Error"
 
-        self.app = uwebserver.WebServer(host=HOST, port=PORT)
+        self.app = uwebserver.WebServer(port=PORT)
         self.app.add_route("/simple", simple_route)
         self.app.add_route("/chunk", iter_route)
         self.app.add_route("/error", error_route)

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 
 import uwebserver
 
-HOST, PORT = "localhost", 8000
+HOST, PORT = "127.0.0.1", 8000
 APP_TIMEOUT, TEST_TIMEOUT = 30, 10
 
 

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -75,6 +75,7 @@ class TestDefaultWebServer(unittest.TestCase):
 
         self.loop = asyncio.new_event_loop()
         self.app_task = self.loop.create_task(asyncio.wait_for(self.app.run(), APP_TIMEOUT))
+        self.loop.run_until_complete(self.app.wait_ready())
 
     def tearDown(self) -> None:
         self.app.close()
@@ -172,6 +173,7 @@ class TestWebServer(unittest.TestCase):
 
         self.loop = asyncio.new_event_loop()
         self.app_task = self.loop.create_task(asyncio.wait_for(self.app.run(), APP_TIMEOUT))
+        self.loop.run_until_complete(self.app.wait_ready())
 
     def tearDown(self) -> None:
         self.app.close()

--- a/uwebserver/__init__.py
+++ b/uwebserver/__init__.py
@@ -340,8 +340,5 @@ class WebServer:
         return self.s and self.s.close()
 
     async def run(self):
-        print("starting web server")
         self.s = await asyncio.start_server(self._handle, self.host, self.port)
-        print("server created")
         await self.s.wait_closed()
-        print("server closed")

--- a/uwebserver/__init__.py
+++ b/uwebserver/__init__.py
@@ -190,6 +190,7 @@ class WebServer:
         self._cah: "Handler" = self._dch  # Catch-all handler
         self._eh: "ErrorHanlder" = self._deh  # Error handler
         self.s: asyncio.Server | None = None
+        self._ready = asyncio.Event()
 
     def route(self, path: str, methods: "Methods" = ("GET",)):
         def w(handler: "Handler"):
@@ -337,8 +338,13 @@ class WebServer:
             await w.wait_closed()
 
     def close(self):
+        print("close called", self.s)
         return self.s and self.s.close()
+
+    async def wait_ready(self):
+        await self._ready.wait()
 
     async def run(self):
         self.s = await asyncio.start_server(self._handle, self.host, self.port)
+        self._ready.set()
         await self.s.wait_closed()

--- a/uwebserver/__init__.py
+++ b/uwebserver/__init__.py
@@ -340,5 +340,8 @@ class WebServer:
         return self.s and self.s.close()
 
     async def run(self):
+        print("starting web server")
         self.s = await asyncio.start_server(self._handle, self.host, self.port)
+        print("server created")
         await self.s.wait_closed()
+        print("server closed")


### PR DESCRIPTION
Fixes ci tests failing on CPython because of the test webserver not being ready when the tests are run.