### PR TITLE
Improve typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,4 +33,16 @@ reportMissingImports = false
 
 [tool.ruff]
 line-length = 100
-lint = { select = ["E", "F", "I", "UP", "SIM"], ignore = ["UP037", "E731"] }
+lint = { select = [
+    "E",
+    "F",
+    "I",
+    "UP",
+    "SIM",
+], ignore = [
+    "UP037",
+    "E731",
+    "SIM105",
+    "F401",
+    "E722",
+] }

--- a/uwebserver/__init__.py
+++ b/uwebserver/__init__.py
@@ -11,9 +11,9 @@ except ImportError:
 
 _is_coro = getattr(asyncio, "iscoroutinefunction", lambda f: type(f).__name__ == "generator")
 
-try:  # noqa
-    import typing  # noqa
-except:  # noqa
+try:
+    import typing
+except:
     pass
 
 try:

--- a/uwebserver/__init__.py
+++ b/uwebserver/__init__.py
@@ -14,12 +14,14 @@ _is_coro = getattr(asyncio, "iscoroutinefunction", lambda f: type(f).__name__ ==
 
 try:
     from collections.abc import Awaitable, Callable, Iterable
-    from typing import TYPE_CHECKING, Literal, TypeAlias, TypeGuard
+    from typing import TYPE_CHECKING, Generic, Literal, TypeAlias, TypeGuard, TypeVar
 except ImportError:
     TYPE_CHECKING = False
+    Generic = type("Generic", (), {"__getitem__": lambda s, n: object})()
 
 
 if TYPE_CHECKING:
+    TStatic = TypeVar("TStatic", bound=str | None)
     StrDict: TypeAlias = "dict[str,str]"
     BytesIter: TypeAlias = "Iterable[bytes]"
     Body: TypeAlias = "bytes|BytesIter|File|None"
@@ -245,13 +247,13 @@ class Response:
         self.headers["content-type"] = ct
 
 
-class WebServer:
+class WebServer(Generic["TStatic"]):
     def __init__(
         self,
         *,
         host: str = "0.0.0.0",
         port: int = 80,
-        static_folder: str | None = "static",
+        static_folder: "TStatic" = "static",
         request_timeout: float = 5,
     ) -> None:
         self.static = static_folder

--- a/uwebserver/__init__.py
+++ b/uwebserver/__init__.py
@@ -39,7 +39,6 @@ _TStatic = TypeVar("_TStatic", bound="str | None")
 _READ_SIZE = micropython.const(128)
 _WRITE_BUFFER_SIZE = micropython.const(128)
 _FILE_INDICATOR = micropython.const(1 << 16)
-_INVALID_STATE = micropython.const(Exception("Invalid state"))
 
 _WRITE_BUFFER = bytearray(_WRITE_BUFFER_SIZE)
 
@@ -142,18 +141,18 @@ class _Future:
         self._er = None
 
     def set_result(self, result):
-        self._r = result if self._r is self._o else _raise(_INVALID_STATE)
+        self._r = result if self._r is self._o else _raise(Exception("Invalid state"))
         self._e.set()
 
     def set_exception(self, exception: BaseException):
-        self._er = exception if self._r is self._o else _raise(_INVALID_STATE)
+        self._er = exception if self._r is self._o else _raise(Exception("Invalid state"))
         self._e.set()
 
     def result(self):
         if self._er is not None:
             raise self._er
         if self._r is self._o:
-            raise _INVALID_STATE
+            raise Exception("Invalid state")
         return self._r
 
     def __await__(self):

--- a/uwebserver/__init__.py
+++ b/uwebserver/__init__.py
@@ -11,10 +11,10 @@ except ImportError:
 
 _is_coro = getattr(asyncio, "iscoroutinefunction", lambda f: type(f).__name__ == "generator")
 
-# fmt: off
-try: import typing  # noqa
-except: pass  # noqa
-# fmt: on
+try:  # noqa
+    import typing  # noqa
+except:  # noqa
+    pass
 
 try:
     from collections.abc import Awaitable, Callable, Iterable

--- a/uwebserver/__init__.py
+++ b/uwebserver/__init__.py
@@ -11,6 +11,10 @@ except ImportError:
 
 _is_coro = getattr(asyncio, "iscoroutinefunction", lambda f: type(f).__name__ == "generator")
 
+# fmt: off
+try: import typing  # noqa
+except: pass  # noqa
+# fmt: on
 
 try:
     from collections.abc import Awaitable, Callable, Iterable
@@ -18,10 +22,9 @@ try:
 except ImportError:
     TYPE_CHECKING = False
     Generic = type("Generic", (), {"__getitem__": lambda s, n: object})()
-
+    TypeVar = type("TypeVar", (), {"__call__": lambda *a, **kw: None})  # type: type[typing.TypeVar] #type: ignore
 
 if TYPE_CHECKING:
-    TStatic = TypeVar("TStatic", bound=str | None)
     StrDict: TypeAlias = "dict[str,str]"
     BytesIter: TypeAlias = "Iterable[bytes]"
     Body: TypeAlias = "bytes|BytesIter|File|None"
@@ -30,6 +33,8 @@ if TYPE_CHECKING:
     ErrorHandler: TypeAlias = "Callable[[Request,Response,Exception],Results|Awaitable[Results]]"
     Methods: TypeAlias = "Iterable[Literal['GET','POST','DELETE','PUT','HEAD','OPTIONS']]"
     Encodings: TypeAlias = "Literal['gzip']"
+
+_TStatic = TypeVar("_TStatic", bound="str | None")
 
 _READ_SIZE = micropython.const(128)
 _WRITE_BUFFER_SIZE = micropython.const(128)
@@ -247,13 +252,13 @@ class Response:
         self.headers["content-type"] = ct
 
 
-class WebServer(Generic["TStatic"]):
+class WebServer(Generic[_TStatic]):
     def __init__(
         self,
         *,
         host: str = "0.0.0.0",
         port: int = 80,
-        static_folder: "TStatic" = "static",
+        static_folder: "_TStatic" = "static",
         request_timeout: float = 5,
     ) -> None:
         self.static = static_folder


### PR DESCRIPTION
Static folder can be set to `None` to disable static folder serving.
This causes typing issues when using the `static` attribute of the WebServer.

This PR tries to fix such issues.